### PR TITLE
Fix list fields stored as JSON

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, Integer, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, String, Text, Integer, Boolean, DateTime, ForeignKey, JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
@@ -17,7 +17,7 @@ class Document(Base):
     mime_type = Column(String(100), nullable=True)
     document_type = Column(String(50), nullable=True)
     is_encrypted = Column(Boolean, default=True)
-    access_permissions = Column(Text, default="[]")
+    access_permissions = Column(JSON, default=list)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     
     trip = relationship("Trip", back_populates="documents")

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, Boolean, DateTime, ForeignKey, Enum
+from sqlalchemy import Column, String, Text, Boolean, DateTime, ForeignKey, Enum, JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
@@ -21,7 +21,7 @@ class Message(Base):
     content = Column(Text, nullable=False)
     message_type = Column(Enum(MessageType), nullable=False, default=MessageType.TEXT)
     is_encrypted = Column(Boolean, default=True)
-    read_by = Column(Text, default="[]")
+    read_by = Column(JSON, default=list)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     
     trip = relationship("Trip", back_populates="messages")


### PR DESCRIPTION
## Summary
- handle lists correctly in message and document models by using JSON columns

## Testing
- `python -m compileall -q backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fff2d4148325b16089b1d7007146